### PR TITLE
Azure PowerShell pindown

### DIFF
--- a/.github/actions/bicep-deploy/action.yaml
+++ b/.github/actions/bicep-deploy/action.yaml
@@ -42,7 +42,8 @@ runs:
     - name: Run Bicep Deploy
       uses: azure/powershell@v2
       with:
-        azPSVersion: 'latest'
+        azPSVersion: '12.5.0'
+        #azPSVersion: 'latest'
         inlineScript: |
           $whatIf = [System.Convert]::ToBoolean($env:WHAT_IF_ENABLED)
 

--- a/.github/actions/bicep-installer/action.yaml
+++ b/.github/actions/bicep-installer/action.yaml
@@ -7,32 +7,36 @@ runs:
   steps:
     - name: Check Az PowerShell Version
       run: |
-        $latestVersion = (Find-Module AZ).Version
-        Write-Host "Latest AZ PowerShell Version: $latestVersion"
-        echo "lastestPowerShellAzVersion=$latestVersion" >> $env:GITHUB_ENV
-
-        $installedModule = Get-InstalledModule -Name AZ -ErrorAction SilentlyContinue
-        $installedVersion = $installedModule.Version
-        Write-Host "Installed AZ PowerShell Version: $installedVersion"
-
-        $runPowerShellAzUpgrade = $true
-
-        if($installedVersion -ne $latestVersion) {
-            Write-Host "Az PowerShell is not at the latest version, running upgrade step..."
-        } else {
-            Write-Host "Az PowerShell is already at the latest version, skipping upgrade step..."
-            $runPowerShellAzUpgrade = $false
+        if(!(Test-Path -Path "/usr/share/az_12.5.0")) {
+        mkdir "/usr/share/az_12.5.0"
+        Save-Module -Name AZ -RequiredVersion 12.5.0 -path "/usr/share/az_12.5.0"
         }
-        echo "runPowerShellAzUpgrade=$runPowerShellAzUpgrade" >> $env:GITHUB_ENV
+        # $latestVersion = (Find-Module AZ).Version
+        # Write-Host "Latest AZ PowerShell Version: $latestVersion"
+        # echo "lastestPowerShellAzVersion=$latestVersion" >> $env:GITHUB_ENV
+
+        # $installedModule = Get-InstalledModule -Name AZ -ErrorAction SilentlyContinue
+        # $installedVersion = $installedModule.Version
+        # Write-Host "Installed AZ PowerShell Version: $installedVersion"
+
+        # $runPowerShellAzUpgrade = $true
+
+        # if($installedVersion -ne $latestVersion) {
+        #     Write-Host "Az PowerShell is not at the latest version, running upgrade step..."
+        # } else {
+        #     Write-Host "Az PowerShell is already at the latest version, skipping upgrade step..."
+        #     $runPowerShellAzUpgrade = $false
+        # }
+        # echo "runPowerShellAzUpgrade=$runPowerShellAzUpgrade" >> $env:GITHUB_ENV
       shell: pwsh
 
-    - name: Upgrade AZ PowerShell
-      uses: azure/powershell@v2
-      if: ${{ env.runPowerShellAzUpgrade == 'true' }}
-      with:
-        azPSVersion: '${{ env.lastestPowerShellAzVersion }}'
-        inlineScript: |
-          Write-Host "Attempted Upgrade of AZ PowerShell to ${{ env.lastestPowerShellAzVersion }}"
+    # - name: Upgrade AZ PowerShell
+    #   uses: azure/powershell@v2
+    #   if: ${{ env.runPowerShellAzUpgrade == 'true' }}
+    #   with:
+    #     azPSVersion: '${{ env.lastestPowerShellAzVersion }}'
+    #     inlineScript: |
+    #       Write-Host "Attempted Upgrade of AZ PowerShell to ${{ env.lastestPowerShellAzVersion }}"
 
     - name: Install Bicep
       run: |


### PR DESCRIPTION
This pull request includes updates to the `.github/actions/bicep-deploy/action.yaml` and `.github/actions/bicep-installer/action.yaml` files to specify a fixed version of Azure PowerShell and simplify the version checking and installation process.

Changes to Azure PowerShell version:

* [`.github/actions/bicep-deploy/action.yaml`](diffhunk://#diff-cc1b03c9e9d7fa081195aadb57199bbd2368652242047e50ac61a76e1586ce0eL45-R46): Updated `azPSVersion` to a fixed version `12.5.0` instead of `latest` to ensure consistency in deployments.

Simplification of version checking and installation:

* [`.github/actions/bicep-installer/action.yaml`](diffhunk://#diff-22191dfa9414648c25e95c8eded9839d62e4b4a408a131fffa844b763c19aaa9L10-R39): Replaced the dynamic version checking and conditional upgrade steps with a fixed installation path for Azure PowerShell version `12.5.0`. This change simplifies the script by removing the need to check for the latest version and conditionally upgrade it.